### PR TITLE
Addressing Consistent Application of Viscous Alpha when Using HybridWindModel

### DIFF
--- a/DiscEvolution/eos.py
+++ b/DiscEvolution/eos.py
@@ -296,19 +296,20 @@ class IrradiatedEOS(EOS_Table):
         psi : Ratio of disk winds to viscous turbulent alpha. Energy carried away by the 
                wind can be accounted by using phi = eps * phi_0, where phi_0 is the value
                used in the wind model and eps < 1. Default: phi = 0.
-        lamda : Magnetic lever arm parameter, default = 1.5
+        e_rad : fraction of energy lost to radiation, default = 1
 
     Notes: 
-        If disk winds are being used, different choices of lamda provide different heating
-        cases. See Suzuki et. al (2016). If:
-        - lamda = 1.5, all (and only) turbulent energy goes into heating.
-        - lamda > 3, e_rad approaches 1, so the weak winds case (from Suzuki et. al 2016) 
-            is applied.
-        - 1.5 < lamda < 3, general case of disk wind heating is applied.
+        If disk winds are being used, different choices of e_rad provide different heating
+        cases. See Suzuki et. al (2016). The special/edge cases are as follows.
+        - If e_rad = 3/(3 + psi), all (and only) turbulent energy goes into heating.
+        - If e_rad ~ 1, the weak winds case (from Suzuki et. al 2016) is applied.
+
+        If the user wishes to be self-consistent, one must choose a magnetic lever 
+        arm parameter (lambda) such that lambda = 1 + psi/(2(1 - e_rad)(3 + psi)). 
     """
     def __init__(self, star, alpha_t, Tc=10, Tmax=1500., mu=2.4, gamma=1.4,
                  kappa=None,
-                 accrete=True, tol=None, psi=0, lamda=1.5): # tol is no longer used
+                 accrete=True, tol=None, psi=0, e_rad=1): # tol is no longer used
         super(IrradiatedEOS, self).__init__()
 
         self._star = star
@@ -332,7 +333,7 @@ class IrradiatedEOS(EOS_Table):
         self._T = None
 
         self._psi = psi
-        self._lamda = lamda
+        self._e_rad = e_rad
 
         self._compute_constants()
 
@@ -383,13 +384,11 @@ class IrradiatedEOS(EOS_Table):
             # Compute the heating from stellar irradiation
             dEdt += star_heat * (f_flat + f_flare * (H/R))
 
+            # Viscous Heating
             # If psi > 0, includes heating from disk winds based off and 
             # derived from the model proposed by Suzuki et. al (2018, 
             #  doi:10.1051/0004-6361/201628955).
-            e_rad = 1 - (self._psi/(3 + self._psi))/(2*(self._lamda - 1))
-            
-            # Viscous Heating
-            visc_heat = e_rad*1.125*alpha*cs*cs * Om_k * (1 + self._psi/3)
+            visc_heat = self._e_rad*1.125*alpha*cs*cs * Om_k * (1 + self._psi/3)
             dEdt += visc_heat*(0.375*tau*Sigma + 1./kappa)
             
             # Prevent heating above the temperature cap:

--- a/DiscEvolution/eos.py
+++ b/DiscEvolution/eos.py
@@ -375,7 +375,8 @@ class IrradiatedEOS(EOS_Table):
 
             # Viscous Heating
             # If psi is given, includes heating from disk winds based off and 
-            # derived from the weak disk winds model proposed by Suzuki et. al (2018)
+            # derived from the weak disk winds model proposed by Suzuki et. al (2018, 
+            #  doi:10.1051/0004-6361/201628955).
             visc_heat = 1.125*alpha*cs*cs * Om_k * (1 + self._psi/3)
             dEdt += visc_heat*(0.375*tau*Sigma + 1./kappa)
             

--- a/DiscEvolution/eos.py
+++ b/DiscEvolution/eos.py
@@ -293,10 +293,11 @@ class IrradiatedEOS(EOS_Table):
         kappa   : Opacity, default=Zhu2012
         accrete : Whether to include heating due to accretion,
                   default=True
+        psi : Ratio of disk winds to viscous turbulent alpha, default = 0
     """
     def __init__(self, star, alpha_t, Tc=10, Tmax=1500., mu=2.4, gamma=1.4,
                  kappa=None,
-                 accrete=True, tol=None): # tol is no longer used
+                 accrete=True, tol=None, psi=0): # tol is no longer used
         super(IrradiatedEOS, self).__init__()
 
         self._star = star
@@ -318,6 +319,8 @@ class IrradiatedEOS(EOS_Table):
             self._kappa = kappa
         
         self._T = None
+
+        self._psi = psi
 
         self._compute_constants()
 
@@ -369,7 +372,9 @@ class IrradiatedEOS(EOS_Table):
             dEdt += star_heat * (f_flat + f_flare * (H/R))
 
             # Viscous Heating
-            visc_heat = 1.125*alpha*cs*cs * Om_k
+            # If psi is given, includes heating from disk winds based off and 
+            # derived from the weak disk winds model proposed by Suzuki et. al (2018)
+            visc_heat = 1.125*alpha*cs*cs * Om_k * (1 + self._psi/3)
             dEdt += visc_heat*(0.375*tau*Sigma + 1./kappa)
             
             # Prevent heating above the temperature cap:

--- a/DiscEvolution/eos.py
+++ b/DiscEvolution/eos.py
@@ -293,10 +293,8 @@ class IrradiatedEOS(EOS_Table):
         kappa   : Opacity, default=Zhu2012
         accrete : Whether to include heating due to accretion,
                   default=True
-        psi : Ratio of disk winds to viscous turbulent alpha. Energy carried away by the 
-               wind can be accounted by using phi = eps * phi_0, where phi_0 is the value
-               used in the wind model and eps < 1. Default: phi = 0.
-        e_rad : fraction of energy lost to radiation, default = 1
+        psi : Ratio of disk winds to viscous turbulent alpha, default: psi = 0.
+        e_rad : fraction of energy lost to radiation (Suzuki et. al 2016), default = 1
 
     Notes: 
         If disk winds are being used, different choices of e_rad provide different heating

--- a/DiscEvolution/eos.py
+++ b/DiscEvolution/eos.py
@@ -293,7 +293,9 @@ class IrradiatedEOS(EOS_Table):
         kappa   : Opacity, default=Zhu2012
         accrete : Whether to include heating due to accretion,
                   default=True
-        psi : Ratio of disk winds to viscous turbulent alpha, default = 0
+        psi : Ratio of disk winds to viscous turbulent alpha. Energy carried away by the 
+               wind can be accounted by using phi = eps * phi_0, where phi_0 is the value
+               used in the wind model and eps < 1. Default: phi = 0.
     """
     def __init__(self, star, alpha_t, Tc=10, Tmax=1500., mu=2.4, gamma=1.4,
                  kappa=None,

--- a/DiscEvolution/viscous_evolution.py
+++ b/DiscEvolution/viscous_evolution.py
@@ -343,7 +343,7 @@ class HybridWindModel(object):
 
     def _init_fluxes_visc(self, disc):
         """Compute the flux due to viscosity"""
-        nuRh = disc.nu *  self._Rh / (1 + self._psi)
+        nuRh = disc.nu *  self._Rh
 
         S = np.zeros(len(nuRh) + 2, dtype='f8')
         S[1:-1] = disc.Sigma_G * nuRh
@@ -373,7 +373,7 @@ class HybridWindModel(object):
     def _init_fluxes_wind(self, disc, dt=0):
         """Compute the flux and mass-loss rate due to the wind"""
         #Use first order Donor cell method:
-        v_DW = 1.5 * (disc.nu/disc.R) * self._psi / (1 + self._psi)
+        v_DW = 1.5 * (disc.nu/disc.R) * self._psi
 
         F = np.zeros(len(disc.Sigma_G) + 1, dtype='f8')
         F[:-1] = v_DW * disc.Sigma_G
@@ -428,13 +428,13 @@ class HybridWindModel(object):
     def max_timestep(self, disc):
         """Courant limited time-step"""
         grid = disc.grid
-        nu = disc.nu / (1 + self._psi)
+        nu = disc.nu
 
         dXe2 = np.diff(2 * np.sqrt(grid.Re)) ** 2
 
         t_visc = ((dXe2 * grid.Rc) / (2 * 3 * nu)).min()
 
-        v_DW   = 1.5 * (disc.nu/grid.Rc) * self._psi / (1 + self._psi)
+        v_DW   = 1.5 * (disc.nu/grid.Rc) * self._psi
         t_wind = (np.diff(0.5*grid.Re**2) / (grid.Rc * v_DW)).min()
 
         return self._tol * min(t_visc, t_wind)


### PR DESCRIPTION
This PR Closes #7. In this PR, I have decided to make `IrradiatedEOS` use viscous alpha instead of total alpha when `HybridWindModel` is used in conjunction. As a result, viscous alpha will be consistently used throughout the EOS classes no matter what gas evolution class is used. This decision affects how disk winds heat the disk, which is why I am currently implementing a method of disk winds heating following [Suzuki et. al 2018](https://arxiv.org/abs/1609.00437). More information on the disk winds heating will come once the implementation is done. 